### PR TITLE
Add an ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,5 @@ RUN apt update; \
     apt remove -y build-essential git gcc g++ make libffi-dev libssl-dev tcl; \
     apt autoremove -y; \
     rm -rf ~/bld ~/sqlcipher
+
+ENTRYPOINT ["sqlcipher"]


### PR DESCRIPTION
This makes it easier to directly run the image, so I could do:

```
docker run ... yspreen/sqlcipher mydb.sqlite
```

And it would open the database.  Currently, I'd have to do this:

```
docker run --entrypoint sqlcipher ... yspreen/sqlcipher mydb.sqlite
```
